### PR TITLE
US4 Added Frontend Features for Endorsement

### DIFF
--- a/templates/partials/topic/topic-menu-list.tpl
+++ b/templates/partials/topic/topic-menu-list.tpl
@@ -15,6 +15,13 @@
 	<a component="topic/unpin" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !pinned }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumb-tack fa-rotate-90 text-secondary"></i> [[topic:thread-tools.unpin]]</a>
 </li>
 
+<li {{{ if endorsed }}}hidden{{{ end }}}>
+	<a component="topic/endorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if endorsed }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-check text-secondary"></i> [[topic:thread-tools.endorse]]</a>
+</li>
+<li {{{ if !endorsed }}}hidden{{{ end }}}>
+	<a component="topic/unendorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !endorsed }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-stop text-secondary"></i> [[topic:thread-tools.unendorse]]</a>
+</li>
+
 <li>
 	<a component="topic/move" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-arrows text-secondary"></i> [[topic:thread-tools.move]]</a>
 </li>

--- a/templates/partials/topics_list.tpl
+++ b/templates/partials/topics_list.tpl
@@ -24,6 +24,10 @@
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>
 				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
+				    <span component="topic/endorsed" class="badge border border-gray-300 text-body {{{ if !./endorsed }}}hidden{{{ end }}}">
+                        <i class="fa fa-check"></i>
+                    <span>[[topic:endorsed]]</span>
+                    </span>
 					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">
 						<i class="fa fa-bell-o"></i>
 						<span>[[topic:watching]]</span>


### PR DESCRIPTION
### New Features
1. Added `Endorse Topic` in `Topic Tools` drop-down menu. Button is activated upon clicked, and the topic will get endorsed.
2. Added `Unendorse Topic` feature that can undo `Endorse Topic` action. Will appear and replace `Endorse Topic` for endorsed topics.
3. Endorsement actions are logged just like other actions, i.e., lock and pin. 
4. Added `Endorsed` tag in topic list (displayed after clicking on a category) for endorsed topics. 

### Testing
1. Automated test is included in another repo. Ensures correct API calls and privileged users have access to this feature.
2. Rendering test is done by user testing. All new features won't trigger explicit errors.
