### PR TITLE
US4: Adding enhancements for endorsement feature

### DIFF
--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -53,9 +53,15 @@
 				</span>
 			</div>
 			{{{ end }}}
+
 			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
-				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
+				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">
+					{{{ if endorsed }}}
+						<span class="checkmark text-success"><i class="fa fa-check-circle"></i></span>
+					{{{ end }}}
+					#{increment(./index, "1")}
+				</a>
 			</div>
 		</div>
 

--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -58,7 +58,7 @@
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">
 					{{{ if endorsed }}}
-						<span class="checkmark text-success"><i class="fa fa-check-circle"></i></span>
+						<span component="topic/endorsed-checkmark" class="checkmark text-success"><i class="fa fa-check-circle" title="An instructor endorsed this post"></i></span>
 					{{{ end }}}
 					#{increment(./index, "1")}
 				</a>

--- a/templates/partials/topic/topic-menu-list.tpl
+++ b/templates/partials/topic/topic-menu-list.tpl
@@ -15,6 +15,13 @@
 	<a component="topic/unpin" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !pinned }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumb-tack fa-rotate-90 text-secondary"></i> [[topic:thread-tools.unpin]]</a>
 </li>
 
+<li {{{ if endorsed }}}hidden{{{ end }}}>
+	<a component="topic/endorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if endorsed }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-check text-secondary"></i> [[topic:thread-tools.endorse]]</a>
+</li>
+<li {{{ if !endorsed }}}hidden{{{ end }}}>
+	<a component="topic/unendorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !endorsed }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-stop text-secondary"></i> [[topic:thread-tools.unendorse]]</a>
+</li>
+
 <li>
 	<a component="topic/move" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-arrows text-secondary"></i> [[topic:thread-tools.move]]</a>
 </li>

--- a/templates/partials/topics_list.tpl
+++ b/templates/partials/topics_list.tpl
@@ -24,6 +24,10 @@
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>
 				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
+				    <span component="topic/endorsed" class="badge border border-gray-300 text-body {{{ if !./endorsed }}}hidden{{{ end }}}">
+                        <i class="fa fa-check"></i>
+                    <span>[[topic:endorsed]]</span>
+                    </span>
 					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">
 						<i class="fa fa-bell-o"></i>
 						<span>[[topic:watching]]</span>


### PR DESCRIPTION
Solves #2 

### New Features
- Added green checkmark next to post number to indicate that a post is endorsed, removed when post is unendorsed
- Added hover element over green checkmark that states that an instructor endorsed the post

### Testing

Manually tested by building and deploying to personal NodeBB account

Testing can be reproduced by the following steps, once on NodeBB website:
1. Navigating to _Announcements_ page
2. Click on a post (if no existing post, click _New Topic_ and enter relevant content and submit)
3. Click on _Topic Tools_ and click the menu option that states _Endorse Topic_
4. Upon clicking on this button, you will see a green checkmark next to the post number
5. When you hover over the green checkmark, you will see a note that says '_An instructor endorsed this post_'
6. To unendorse, click on _Topic Tools_ again and click the menu option that states _Unendorse Topic_
7. The green checkmark will disappear
